### PR TITLE
STH31: Add support for internal heater

### DIFF
--- a/MT3620_Grove_Shield_Library/Sensors/GroveTempHumiSHT31.c
+++ b/MT3620_Grove_Shield_Library/Sensors/GroveTempHumiSHT31.c
@@ -13,6 +13,8 @@
 
 #define CMD_SOFT_RESET		(0x30a2)
 #define CMD_SINGLE_HIGH		(0x2400)
+#define CMD_HEATER_ENABLE	(0x306d)
+#define CMD_HEATER_DISABLE	(0x3066)
 
 typedef struct
 {
@@ -89,6 +91,22 @@ void GroveTempHumiSHT31_Read(void* inst)
 
 	this->Temperature = (float)ST * 175 / 0xffff - 45;
 	this->Humidity = (float)SRH * 100 / 0xffff;
+}
+
+void GroveTempHumiSHT31_EnableHeater(void* inst)
+{
+	GroveTempHumiSHT31Instance* this = (GroveTempHumiSHT31Instance*)inst;
+
+	SendCommand(this, CMD_HEATER_ENABLE);
+	usleep(20000);
+}
+
+void GroveTempHumiSHT31_DisableHeater(void* inst)
+{
+	GroveTempHumiSHT31Instance* this = (GroveTempHumiSHT31Instance*)inst;
+
+	SendCommand(this, CMD_HEATER_DISABLE);
+	usleep(20000);
 }
 
 float GroveTempHumiSHT31_GetTemperature(void* inst)

--- a/MT3620_Grove_Shield_Library/Sensors/GroveTempHumiSHT31.h
+++ b/MT3620_Grove_Shield_Library/Sensors/GroveTempHumiSHT31.h
@@ -5,5 +5,7 @@
 #pragma once
 void* GroveTempHumiSHT31_Open(int i2cFd);
 void GroveTempHumiSHT31_Read(void* inst);
+void GroveTempHumiSHT31_EnableHeater(void* inst);
+void GroveTempHumiSHT31_DisableHeater(void* inst);
 float GroveTempHumiSHT31_GetTemperature(void* inst);
 float GroveTempHumiSHT31_GetHumidity(void* inst);


### PR DESCRIPTION
The internal heater on SHT31 can be used to evaporate left over
condensation on the sensor and results in more accurate measurements.

Signed-off-by: Felipe Balbi <felipe.balbi@microsoft.com>